### PR TITLE
Remove unused ID field from OrderResponse

### DIFF
--- a/payments/model/dependentmodels.go
+++ b/payments/model/dependentmodels.go
@@ -1,7 +1,6 @@
 package model
 
 type OrderResponse struct {
-	ID     uint         `json:"order_id"`
 	CartID uint         `json:"cart_id"`
 	Cart   CartResponse `json:"cart,omitempty"`
 }


### PR DESCRIPTION
The ID field has been removed from the OrderResponse structure in the client code to reflect the changes in the service-side API. This change is necessary to maintain compatibility with the updated API which no longer includes the ID field in the OrderResponse. Clients relying on this data structure will need this update to ensure proper operation.